### PR TITLE
Make itoa and setenv accesable in C++

### DIFF
--- a/sdk/include/stdlib.h
+++ b/sdk/include/stdlib.h
@@ -1,0 +1,22 @@
+#ifdef __cplusplus
+#define _GLIBCXX_INCLUDE_NEXT_C_HEADERS
+#include_next <stdlib.h>
+#undef _GLIBCXX_INCLUDE_NEXT_C_HEADERS
+
+#undef setenv
+#undef itoa
+
+extern "C++"
+{
+namespace std
+{
+  using ::setenv;
+  using ::itoa;
+} // namespace std
+
+using std::setenv;
+using std::itoa;
+} // extern C++
+
+#endif // __cplusplus
+#include_next <stdlib.h>


### PR DESCRIPTION
This is a override header with code similiar to libstdc++-v3
Works with C and C++